### PR TITLE
Fix Dark Mode Persistence Between Login Pages

### DIFF
--- a/resources/views/components/layouts/auth/simple.blade.php
+++ b/resources/views/components/layouts/auth/simple.blade.php
@@ -5,9 +5,14 @@
         <!-- Script de gestion du thème -->
         <script>
             (function() {
-                const theme = localStorage.getItem('theme') || 'light';
-                document.documentElement.classList.remove('light', 'dark');
-                document.documentElement.classList.add(theme);
+                const applyTheme = function() {
+                    const theme = localStorage.getItem('theme') || 'light';
+                    document.documentElement.classList.remove('light', 'dark');
+                    document.documentElement.classList.add(theme);
+                };
+
+                // Apply theme immediately
+                applyTheme();
 
                 window.toggleTheme = function() {
                     const html = document.documentElement;
@@ -20,6 +25,9 @@
 
                     window.dispatchEvent(new CustomEvent('theme-changed', { detail: { theme: newTheme } }));
                 };
+
+                // Re-apply theme after Livewire navigation
+                document.addEventListener('livewire:navigated', applyTheme);
             })();
         </script>
     </head>

--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -28,7 +28,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         session(['auth.password_confirmed_at' => time()]);
 
-        $this->redirectIntended(default: route('dashboard', absolute: false), navigate: true);
+        $this->redirectIntended(default: route('dashboard', absolute: false));
     }
 }; ?>
 

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -40,7 +40,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         RateLimiter::clear($this->throttleKey());
         Session::regenerate();
 
-        $this->redirectIntended(default: route('admin.dashboard', absolute: false), navigate: true);
+        $this->redirectIntended(default: route('admin.dashboard', absolute: false));
     }
 
     /**

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -31,7 +31,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         Auth::login($user);
 
-        $this->redirectIntended(route('admin.dashboard', absolute: false), navigate: true);
+        $this->redirectIntended(route('admin.dashboard', absolute: false));
     }
 }; ?>
 

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -64,7 +64,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         Session::flash('status', __($status));
 
-        $this->redirectRoute('login', navigate: true);
+        $this->redirectRoute('login');
     }
 }; ?>
 

--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -13,7 +13,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     public function sendVerification(): void
     {
         if (Auth::user()->hasVerifiedEmail()) {
-            $this->redirectIntended(default: route('dashboard', absolute: false), navigate: true);
+            $this->redirectIntended(default: route('dashboard', absolute: false));
 
             return;
         }
@@ -30,7 +30,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     {
         $logout();
 
-        $this->redirect('/', navigate: true);
+        $this->redirect('/');
     }
 }; ?>
 

--- a/resources/views/livewire/settings/delete-user-form.blade.php
+++ b/resources/views/livewire/settings/delete-user-form.blade.php
@@ -18,7 +18,7 @@ new class extends Component {
 
         tap(Auth::user(), $logout(...))->delete();
 
-        $this->redirect('/', navigate: true);
+        $this->redirect('/');
     }
 }; ?>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,8 +3,11 @@ import forms from '@tailwindcss/forms';
 
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: 'class',
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
+        './vendor/livewire/flux-pro/stubs/**/*.blade.php',
+        './vendor/livewire/flux/stubs/**/*.blade.php',
         './storage/framework/views/*.php',
         './resources/views/**/*.blade.php',
     ],


### PR DESCRIPTION
- Fix Alpine.navigate error by removing unsupported 'navigate: true' parameter from Livewire redirects
- Improve dark mode persistence across authentication pages by adding livewire:navigated event listener
- Add Flux component paths to Tailwind config for proper styling on profile page
- Enable 'class' dark mode in Tailwind configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)