### PR TITLE
Resolve Alpine.js Plugin and Instance Errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
+                "@alpinejs/collapse": "^3.15.0",
                 "alpinejs": "^3.15.0",
                 "autoprefixer": "^10.4.20",
                 "axios": "^1.7.4",
@@ -18,6 +19,12 @@
                 "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
                 "lightningcss-linux-x64-gnu": "^1.29.1"
             }
+        },
+        "node_modules/@alpinejs/collapse": {
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.0.tgz",
+            "integrity": "sha512-RREZVE67/2E7rDZIxw3B5BGAFBm1x/16+3jeyjj+Fky4wPBqnhGCQZujkiggrOmdU6mcZPixYxkKFlhKfQMAXw==",
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.6",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "dev": "vite"
     },
     "dependencies": {
+        "@alpinejs/collapse": "^3.15.0",
         "alpinejs": "^3.15.0",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.4",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,9 +1,13 @@
 import './bootstrap';
 import Alpine from 'alpinejs';
+import collapse from '@alpinejs/collapse';
 
-// Initialiser Alpine.js
+// Enregistrer le plugin Collapse
+Alpine.plugin(collapse);
+
+// Rendre Alpine disponible globalement
+// Livewire démarrera Alpine automatiquement, donc on ne l'appelle pas Alpine.start()
 window.Alpine = Alpine;
-Alpine.start();
 
 document.addEventListener('DOMContentLoaded', function() {
 


### PR DESCRIPTION
- Installer et configurer le plugin Collapse d'Alpine pour x-collapse
- Résoudre le problème des instances multiples en laissant Livewire gérer le démarrage d'Alpine
- Supprimer l'appel Alpine.start() pour éviter les conflits avec Livewire v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)