### PR TITLE
🔧 Corriger l'affichage de la page de profil

### DIFF
--- a/resources/views/livewire/settings/appearance.blade.php
+++ b/resources/views/livewire/settings/appearance.blade.php
@@ -1,8 +1,9 @@
 <?php
 
+use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
-new class extends Component {
+new #[Layout('components.layouts.app')] class extends Component {
     //
 }; ?>
 

--- a/resources/views/livewire/settings/password.blade.php
+++ b/resources/views/livewire/settings/password.blade.php
@@ -4,9 +4,10 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
-new class extends Component {
+new #[Layout('components.layouts.app')] class extends Component {
     public string $current_password = '';
     public string $password = '';
     public string $password_confirmation = '';

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -4,9 +4,10 @@ use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Validation\Rule;
+use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
-new class extends Component {
+new #[Layout('components.layouts.app')] class extends Component {
     public string $name = '';
     public string $email = '';
 


### PR DESCRIPTION
- Ajouter l'attribut Layout('components.layouts.app') aux vues settings
- Cela permet d'afficher le layout admin complet (sidebar + navbar) pour les pages de profil, mot de passe et apparence
- Correction du problème où les pages settings n'affichaient pas correctement

Le problème était que les vues Volt settings n'avaient pas de layout défini, donc elles s'affichaient sans la structure admin. Maintenant elles utilisent le layout app avec sidebar et navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)