### PR TITLE
Investigate Sidebar/Navbar Application Issue

### DIFF
--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -8,13 +8,8 @@
         <!-- Sidebar -->
         <aside
             x-data="{
-                open: false,
+                open: window.innerWidth >= 1024,
                 init() {
-                    // Initialiser l'état après le chargement complet d'Alpine
-                    this.$nextTick(() => {
-                        this.open = window.innerWidth >= 1024;
-                    });
-
                     // Gérer le redimensionnement
                     window.addEventListener('resize', () => {
                         if (window.innerWidth >= 1024 && !this.open) {


### PR DESCRIPTION
L'état initial de la sidebar est maintenant directement défini en fonction de la largeur de l'écran, éliminant le flash visuel causé par l'initialisation différée avec $nextTick.

Problème résolu :
- La sidebar s'ouvrait toujours fermée puis s'ajustait immédiatement sur desktop
- Cela causait un effet de "flash" désagréable au chargement de la page

Solution :
- Initialiser directement open avec window.innerWidth >= 1024
- Simplifier la fonction init() en gardant seulement le gestionnaire de resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)