### PR TITLE
🎨 Corriger la bande noire en mode sombre sur la page d'accueil

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -2668,7 +2668,7 @@ aside img[alt="avatar"] {
 
 /* Fond et texte général */
 .dark body {
-    background-color: #0f0f0f;
+    background-color: #1a1a1a;
     color: #e0e0e0;
 }
 
@@ -3153,7 +3153,7 @@ aside img[alt="avatar"] {
 
 /* Main content background */
 .dark main {
-    background-color: #0f0f0f !important;
+    background-color: #1a1a1a !important;
 }
 
 /* Avatar et user menu */


### PR DESCRIPTION
Harmonise les couleurs de fond en mode sombre pour éliminer la bande noire visible entre le header et le contenu principal. Le background du body et du main sont maintenant tous deux en #1a1a1a au lieu de #0f0f0f, créant une apparence cohérente et professionnelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)