### PR TITLE
🔧 Corriger l'upload d'images et la persistance du thème sombre

### DIFF
--- a/app/Http/Controllers/Admin/PhotoController.php
+++ b/app/Http/Controllers/Admin/PhotoController.php
@@ -4,8 +4,6 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Photo;
 use Illuminate\Http\Request;
-use Intervention\Image\ImageManager;
-use Intervention\Image\Drivers\Gd\Driver;
 use Exception;
 
 class PhotoController extends Controller
@@ -36,19 +34,14 @@ class PhotoController extends Controller
                 return redirect()->back()->withErrors(['photo' => 'Erreur lors du téléchargement de l\'image.']);
             }
 
-            // Créer une instance de ImageManager avec le driver GD
-            $manager = new ImageManager(new Driver());
+            // Lire le contenu de l'image
+            $imageData = file_get_contents($imageFile->getRealPath());
 
-            // Lire et traiter l'image
-            $image = $manager->read($imageFile->getRealPath());
+            // Détecter le type MIME
+            $mimeType = $imageFile->getMimeType();
 
-            // Redimensionner l'image (scaleDown ne redimensionne que si l'image est plus grande)
-            $image->scaleDown(width: 1200);
-
-            // Encoder en JPEG avec qualité 75
-            $encodedImage = $image->toJpeg(quality: 75);
-
-            $base64Image = 'data:image/jpeg;base64,' . base64_encode($encodedImage);
+            // Créer le format base64
+            $base64Image = 'data:' . $mimeType . ';base64,' . base64_encode($imageData);
 
             Photo::create([
                 'image' => $base64Image,

--- a/resources/views/components/head.blade.php
+++ b/resources/views/components/head.blade.php
@@ -14,8 +14,16 @@
 <script>
     // Initialiser le thème avant le rendu de la page pour éviter le flash
     (function() {
-        const theme = localStorage.getItem('theme') || 'light';
-        document.documentElement.classList.add(theme);
+        // Fonction pour appliquer le thème
+        function applyTheme() {
+            const theme = localStorage.getItem('theme') || 'light';
+            // Important: enlever toute classe existante avant d'ajouter le thème
+            document.documentElement.classList.remove('light', 'dark');
+            document.documentElement.classList.add(theme);
+        }
+
+        // Appliquer le thème initialement
+        applyTheme();
 
         // Fonction globale pour toggle le thème
         window.toggleTheme = function() {
@@ -30,6 +38,11 @@
             // Dispatch event pour permettre aux composants de réagir
             window.dispatchEvent(new CustomEvent('theme-changed', { detail: { theme: newTheme } }));
         };
+
+        // Réappliquer le thème après chaque navigation Livewire
+        document.addEventListener('livewire:navigated', () => {
+            applyTheme();
+        });
     })();
 </script>
 

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -14,10 +14,16 @@
 <script>
     // Initialiser le thème avant le rendu de la page pour éviter le flash
     (function() {
-        const theme = localStorage.getItem('theme') || 'light';
-        // Important: enlever toute classe existante avant d'ajouter le thème
-        document.documentElement.classList.remove('light', 'dark');
-        document.documentElement.classList.add(theme);
+        // Fonction pour appliquer le thème
+        function applyTheme() {
+            const theme = localStorage.getItem('theme') || 'light';
+            // Important: enlever toute classe existante avant d'ajouter le thème
+            document.documentElement.classList.remove('light', 'dark');
+            document.documentElement.classList.add(theme);
+        }
+
+        // Appliquer le thème initialement
+        applyTheme();
 
         // Fonction globale pour toggle le thème
         window.toggleTheme = function() {
@@ -32,6 +38,11 @@
             // Dispatch event pour permettre aux composants de réagir
             window.dispatchEvent(new CustomEvent('theme-changed', { detail: { theme: newTheme } }));
         };
+
+        // Réappliquer le thème après chaque navigation Livewire
+        document.addEventListener('livewire:navigated', () => {
+            applyTheme();
+        });
     })();
 </script>
 


### PR DESCRIPTION
Corrections multiples :

1. Upload d'images sans extension GD :
   - Suppression de la dépendance à Intervention Image
   - Utilisation de file_get_contents et base64_encode natifs
   - Plus besoin de l'extension PHP GD ou Imagick
   - L'image est maintenant stockée directement en base64

2. Persistance du thème sombre avec wire:navigate :
   - Ajout d'un écouteur livewire:navigated
   - Le thème est maintenant réappliqué après chaque navigation SPA
   - Correction dans partials/head.blade.php et components/head.blade.php
   - Le mode sombre reste actif lors de la navigation entre pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)