### PR TITLE
🎨 Corriger la taille du logo dans la sidebar admin

### DIFF
--- a/resources/views/components/app-logo-icon.blade.php
+++ b/resources/views/components/app-logo-icon.blade.php
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="w-full h-full">
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" {{ $attributes->merge(['class' => '']) }}>
     <defs>
         <linearGradient id="autumn" x1="0%" y1="0%" x2="100%" y2="100%">
             <stop offset="0%" style="stop-color:#bc6c25;stop-opacity:1" />

--- a/resources/views/components/app-logo.blade.php
+++ b/resources/views/components/app-logo.blade.php
@@ -1,6 +1,8 @@
-<div class="flex aspect-square size-8 items-center justify-center rounded-md bg-accent-content text-accent-foreground">
-    <x-app-logo-icon class="size-5 fill-current text-white dark:text-black" />
-</div>
-<div class="ms-1 grid flex-1 text-start text-sm">
-    <span class="mb-0.5 truncate leading-tight font-semibold">Laravel Starter Kit</span>
+<div class="flex items-center gap-2">
+    <div class="flex aspect-square size-8 items-center justify-center rounded-md bg-gradient-to-br from-orange-600 to-orange-400">
+        <x-app-logo-icon class="size-5" />
+    </div>
+    <div class="grid flex-1 text-start text-sm">
+        <span class="mb-0.5 truncate leading-tight font-semibold text-gray-900 dark:text-white">Mata & Kris</span>
+    </div>
 </div>

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -36,8 +36,8 @@
 
             <!-- Logo -->
             <div class="h-16 flex items-center justify-center shrink-0 border-b border-gray-200 dark:border-gray-800">
-                <a href="{{ route('admin.dashboard') }}" class="flex items-center justify-center" :class="open ? 'w-12 h-12' : 'w-10 h-10'">
-                    <x-app-logo-icon />
+                <a href="{{ route('admin.dashboard') }}" class="flex items-center justify-center">
+                    <x-app-logo-icon :class="open ? 'w-12 h-12' : 'w-10 h-10'" />
                 </a>
             </div>
 


### PR DESCRIPTION
- Déplacer l'attribut de classe :class vers le composant app-logo-icon
- Permettre au composant app-logo-icon d'accepter des classes personnalisées
- Mettre à jour le composant app-logo avec le bon nom "Mata & Kris"
- Ajouter des styles de mode sombre pour le texte du logo

Résout le problème du logo M & K qui était énorme dans la sidebar admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)