### PR TITLE
🐛 Corriger le positionnement de la sidebar et Alpine.js

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,8 +6,10 @@ import collapse from '@alpinejs/collapse';
 Alpine.plugin(collapse);
 
 // Rendre Alpine disponible globalement
-// Livewire démarrera Alpine automatiquement, donc on ne l'appelle pas Alpine.start()
 window.Alpine = Alpine;
+
+// Démarrer Alpine.js
+Alpine.start();
 
 document.addEventListener('DOMContentLoaded', function() {
 

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -4,7 +4,7 @@
     @include('partials.head')
 </head>
 <body class="min-h-screen bg-zinc-50 dark:bg-zinc-900">
-    <div class="flex min-h-screen">
+    <div class="flex flex-row min-h-screen">
         <!-- Sidebar -->
         <aside
             x-data="{


### PR DESCRIPTION
- Ajouter flex-row explicitement au conteneur principal
- Démarrer Alpine.js explicitement au lieu de compter sur Livewire
- Cela devrait corriger le problème de la sidebar qui s'affichait en entête

🤖 Generated with [Claude Code](https://claude.com/claude-code)