### PR TITLE
🐛 Corriger le conflit de multiples instances Alpine.js

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,10 +6,8 @@ import collapse from '@alpinejs/collapse';
 Alpine.plugin(collapse);
 
 // Rendre Alpine disponible globalement
+// Livewire démarrera Alpine automatiquement, donc on ne l'appelle pas Alpine.start()
 window.Alpine = Alpine;
-
-// Démarrer Alpine.js
-Alpine.start();
 
 document.addEventListener('DOMContentLoaded', function() {
 


### PR DESCRIPTION
- Retirer Alpine.start() car Livewire démarre Alpine automatiquement
- Cela corrige l'erreur "Detected multiple instances of Alpine running"

🤖 Generated with [Claude Code](https://claude.com/claude-code)