### PR TITLE
Resolve Multiple Alpine Instances Conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
         "": {
             "dependencies": {
                 "@alpinejs/collapse": "^3.15.0",
-                "alpinejs": "^3.15.0",
                 "autoprefixer": "^10.4.20",
                 "axios": "^1.7.4",
                 "concurrently": "^9.0.1",
@@ -723,30 +722,6 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "license": "MIT"
-        },
-        "node_modules/@vue/reactivity": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.1.5"
-            }
-        },
-        "node_modules/@vue/shared": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
-            "license": "MIT"
-        },
-        "node_modules/alpinejs": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.0.tgz",
-            "integrity": "sha512-lpokA5okCF1BKh10LG8YjqhfpxyHBk4gE7boIgVHltJzYoM7O9nK3M7VlntLEJGsVmu7U/RzUWajmHREGT38Eg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "~3.1.1"
-            }
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     },
     "dependencies": {
         "@alpinejs/collapse": "^3.15.0",
-        "alpinejs": "^3.15.0",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.4",
         "concurrently": "^9.0.1",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,13 +1,12 @@
 import './bootstrap';
-import Alpine from 'alpinejs';
 import collapse from '@alpinejs/collapse';
 
-// Enregistrer le plugin Collapse
-Alpine.plugin(collapse);
-
-// Rendre Alpine disponible globalement
-// Livewire démarrera Alpine automatiquement, donc on ne l'appelle pas Alpine.start()
-window.Alpine = Alpine;
+// Utiliser l'instance Alpine fournie par Livewire pour éviter les conflits
+// Livewire inclut déjà Alpine.js, nous devons donc utiliser son instance
+document.addEventListener('livewire:init', () => {
+    // L'instance Alpine de Livewire est disponible globalement
+    window.Alpine.plugin(collapse);
+});
 
 document.addEventListener('DOMContentLoaded', function() {
 


### PR DESCRIPTION
- Retirer l'import séparé d'Alpine.js de app.js
- Utiliser l'instance Alpine fournie par Livewire au lieu d'en créer une nouvelle
- Enregistrer le plugin Collapse via l'événement livewire:init
- Retirer la dépendance alpinejs de package.json (Livewire l'inclut déjà)
- Rebuild des assets avec les nouvelles configurations

Cela corrige l'erreur "Detected multiple instances of Alpine running" qui se produisait car nous importions Alpine séparément alors que Livewire en fournit déjà une instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)