### PR TITLE
✨ Simplifier complètement la configuration Alpine.js pour utiliser la…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
     "packages": {
         "": {
             "dependencies": {
-                "@alpinejs/collapse": "^3.15.0",
                 "autoprefixer": "^10.4.20",
                 "axios": "^1.7.4",
                 "concurrently": "^9.0.1",
@@ -18,12 +17,6 @@
                 "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
                 "lightningcss-linux-x64-gnu": "^1.29.1"
             }
-        },
-        "node_modules/@alpinejs/collapse": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.0.tgz",
-            "integrity": "sha512-RREZVE67/2E7rDZIxw3B5BGAFBm1x/16+3jeyjj+Fky4wPBqnhGCQZujkiggrOmdU6mcZPixYxkKFlhKfQMAXw==",
-            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.6",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
         "dev": "vite"
     },
     "dependencies": {
-        "@alpinejs/collapse": "^3.15.0",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.4",
         "concurrently": "^9.0.1",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,12 +1,8 @@
 import './bootstrap';
-import collapse from '@alpinejs/collapse';
 
-// Utiliser l'instance Alpine fournie par Livewire pour éviter les conflits
-// Livewire inclut déjà Alpine.js, nous devons donc utiliser son instance
-document.addEventListener('livewire:init', () => {
-    // L'instance Alpine de Livewire est disponible globalement
-    window.Alpine.plugin(collapse);
-});
+// Livewire 3 inclut déjà Alpine.js ET le plugin Collapse par défaut
+// Pas besoin d'importer ou d'enregistrer quoi que ce soit
+// L'instance Alpine de Livewire est automatiquement disponible globalement
 
 document.addEventListener('DOMContentLoaded', function() {
 


### PR DESCRIPTION
… version de Livewire

- Retirer toutes les dépendances Alpine.js séparées (alpinejs + @alpinejs/collapse)
- Livewire 3 inclut déjà Alpine.js ET le plugin Collapse par défaut
- Plus besoin d'importer ou d'enregistrer quoi que ce soit
- Cela élimine complètement les conflits de multiples instances Alpine
- Rebuild des assets avec la configuration simplifiée

Cette approche est plus propre et utilise directement ce que Livewire fournit, évitant tous les problèmes de timing et de conflits d'instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)