### PR TITLE
Manage Concert Photos in Admin Panel

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1991,12 +1991,21 @@ aside img[alt="avatar"] {
 }
 
 .dashboard-header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--color-light);
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 3rem;
-    padding-bottom: 2rem;
+    padding: 1.5rem 0 2rem;
     border-bottom: 2px solid #f0f0f0;
+    transition: box-shadow 0.3s ease;
+}
+
+.dashboard-header.scrolled {
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
 }
 
 .dashboard-title {
@@ -3457,6 +3466,7 @@ aside img[alt="avatar"] {
 }
 
 .dark .dashboard-header {
+    background: #1a1a1a;
     border-bottom-color: #404040;
 }
 


### PR DESCRIPTION
L'entête de la page de gestion des concerts et des photos reste maintenant fixe lors du défilement, permettant un accès permanent aux boutons d'ajout.

Modifications apportées:
- Ajout de position: sticky sur .dashboard-header
- Ajout d'un fond pour masquer le contenu qui défile en dessous
- Ajout d'une ombre au scroll pour un effet visuel élégant
- Support du mode sombre avec background adapté
- Conservation du comportement responsive existant

🤖 Generated with [Claude Code](https://claude.com/claude-code)