### PR TITLE
Fix Oversized Icons on Profile Page

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -3954,6 +3954,39 @@ aside img[alt="avatar"] {
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
 }
 
+/* Profile page layout override */
+.profile-page .mt-5.w-full.max-w-lg {
+    max-width: 100%;
+}
+
+/* Fixed icon sizes for profile page */
+.profile-badge svg {
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+}
+
+.profile-meta-item svg {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+.profile-card-header svg {
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+.profile-form-actions svg {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+.success-message svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+}
+
 /* --- Danger Zone --- */
 .danger-zone {
     width: 100%;

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -70,7 +70,7 @@ new #[Layout('components.layouts.app')] class extends Component {
     }
 }; ?>
 
-<section class="w-full">
+<section class="w-full profile-page">
     @include('partials.settings-heading')
 
     <x-settings.layout :heading="__('Profile')" :subheading="__('Update your name and email address')">


### PR DESCRIPTION
- Augmenter la largeur maximale de la page de profil pour éviter le débordement du texte
- Fixer les tailles des icônes SVG pour éviter qu'elles soient géantes
- Ajouter une classe 'profile-page' pour cibler spécifiquement cette page

🤖 Generated with [Claude Code](https://claude.com/claude-code)